### PR TITLE
Clarify MCP server and bridge naming

### DIFF
--- a/McpMod.cs
+++ b/McpMod.cs
@@ -21,7 +21,7 @@ public static partial class McpMod
 {
     public const string Version = "0.3.4";
     public const int DefaultPort = 15526;
-    private const string ConfigFileName = "SpireLensMcp.conf";
+    private const string ConfigFileName = "SpireLensMcpBridge.conf";
 
     private static HttpListener? _listener;
     private static Thread? _serverThread;
@@ -49,7 +49,7 @@ public static partial class McpMod
                 var defaultConfig = new Dictionary<string, object> { ["port"] = DefaultPort };
                 string json = JsonSerializer.Serialize(defaultConfig, _jsonOptions);
                 File.WriteAllText(configPath, json);
-                GD.Print($"[SpireLens MCP] Created default config at {configPath}");
+                GD.Print($"[SpireLensMcpBridge] Created default config at {configPath}");
                 return DefaultPort;
             }
 
@@ -62,12 +62,12 @@ public static partial class McpMod
                 return port;
             }
 
-            GD.PrintErr($"[SpireLens MCP] Invalid or missing 'port' in {configPath}, using default {DefaultPort}");
+            GD.PrintErr($"[SpireLensMcpBridge] Invalid or missing 'port' in {configPath}, using default {DefaultPort}");
             return DefaultPort;
         }
         catch (Exception ex)
         {
-            GD.PrintErr($"[SpireLens MCP] Failed to load config: {ex.Message}, using default port {DefaultPort}");
+            GD.PrintErr($"[SpireLensMcpBridge] Failed to load config: {ex.Message}, using default port {DefaultPort}");
             return DefaultPort;
         }
     }
@@ -93,15 +93,15 @@ public static partial class McpMod
             _serverThread = new Thread(ServerLoop)
             {
                 IsBackground = true,
-                Name = "SpireLensMcp_Server"
+                Name = "SpireLensMcpBridge_Server"
             };
             _serverThread.Start();
 
-            GD.Print($"[SpireLens MCP] v{Version} server started on http://localhost:{port}/");
+            GD.Print($"[SpireLensMcpBridge] v{Version} server started on http://localhost:{port}/");
         }
         catch (Exception ex)
         {
-            GD.PrintErr($"[SpireLens MCP] Failed to start: {ex}");
+            GD.PrintErr($"[SpireLensMcpBridge] Failed to start: {ex}");
         }
     }
 
@@ -114,7 +114,7 @@ public static partial class McpMod
         catch (Exception ex)
         {
             GD.PrintErr(
-                $"[SpireLens MCP] Harmony patches unavailable; continuing without optional UI injection: {ex}");
+                $"[SpireLensMcpBridge] Harmony patches unavailable; continuing without optional UI injection: {ex}");
         }
     }
 
@@ -124,7 +124,7 @@ public static partial class McpMod
         while (_mainThreadQueue.TryDequeue(out var action) && processed < 10)
         {
             try { action(); }
-            catch (Exception ex) { GD.PrintErr($"[SpireLens MCP] Main thread action error: {ex}"); }
+            catch (Exception ex) { GD.PrintErr($"[SpireLensMcpBridge] Main thread action error: {ex}"); }
             processed++;
         }
     }
@@ -187,7 +187,7 @@ public static partial class McpMod
 
             if (path == "/")
             {
-                SendJson(response, new { message = $"Hello from SpireLens MCP v{Version}", status = "ok" });
+                SendJson(response, new { message = $"Hello from SpireLensMcpBridge v{Version}", status = "ok" });
             }
             else if (path == "/api/v1/singleplayer")
             {
@@ -273,7 +273,7 @@ public static partial class McpMod
         }
         catch (Exception ex)
         {
-            GD.PrintErr($"[SpireLens MCP] HandleGetMultiplayerState: {ex}");
+            GD.PrintErr($"[SpireLensMcpBridge] HandleGetMultiplayerState: {ex}");
             try
             {
                 response.StatusCode = 500;
@@ -342,7 +342,7 @@ public static partial class McpMod
                 }
                 catch (Exception ex)
                 {
-                    GD.PrintErr($"[SpireLens MCP] FormatAsMarkdown failed, returning JSON: {ex}");
+                    GD.PrintErr($"[SpireLensMcpBridge] FormatAsMarkdown failed, returning JSON: {ex}");
                     SendJson(response, state);
                 }
             }
@@ -353,7 +353,7 @@ public static partial class McpMod
         }
         catch (Exception ex)
         {
-            GD.PrintErr($"[SpireLens MCP] HandleGetState: {ex}");
+            GD.PrintErr($"[SpireLensMcpBridge] HandleGetState: {ex}");
             try
             {
                 response.StatusCode = 500;

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1,6 +1,6 @@
 """MCP server bridge for Slay the Spire 2.
 
-Connects to the SpireLensMcp mod's HTTP server and exposes game actions
+Connects to the SpireLensMcpBridge in-game HTTP bridge and exposes game actions
 as MCP tools for Claude Desktop / Claude Code.
 """
 
@@ -11,7 +11,7 @@ import sys
 import httpx
 from mcp.server.fastmcp import FastMCP
 
-mcp = FastMCP("sts2")
+mcp = FastMCP("spire-lens-mcp")
 
 _base_url: str = "http://localhost:15526"
 _trust_env: bool = True
@@ -55,7 +55,7 @@ async def _mp_post(body: dict) -> str:
 
 def _handle_error(e: Exception) -> str:
     if isinstance(e, httpx.ConnectError):
-        return "Error: Cannot connect to SpireLensMcp mod. Is the game running with the mod enabled?"
+        return "Error: Cannot connect to SpireLensMcpBridge at localhost:15526. Is STS2 running with the bridge mod enabled?"
     if isinstance(e, httpx.HTTPStatusError):
         return f"Error: HTTP {e.response.status_code} — {e.response.text}"
     return f"Error: {e}"
@@ -889,7 +889,7 @@ async def mp_crystal_sphere_proceed() -> str:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="SpireLens MCP Server")
+    parser = argparse.ArgumentParser(description="spire-lens-mcp server")
     parser.add_argument("--port", type=int, default=15526, help="Game HTTP server port")
     parser.add_argument("--host", type=str, default="localhost", help="Game HTTP server host")
     parser.add_argument("--no-trust-env", action="store_true", help="Ignore HTTP_PROXY/HTTPS_PROXY environment variables")

--- a/mod_manifest.json
+++ b/mod_manifest.json
@@ -1,8 +1,8 @@
 {
-  "id": "SpireLensMcp",
-  "name": "SpireLens MCP",
+  "id": "SpireLensMcpBridge",
+  "name": "SpireLens MCP Bridge",
   "author": "nelsong6",
-  "description": "MCP bridge for Slay the Spire 2 — exposes game state and actions over HTTP for SpireLens-driven validation. Vendored from kunology/STS2MCP under MIT.",
+  "description": "In-game HTTP bridge mod for Slay the Spire 2. Exposes game state and actions on localhost:15526 for the external spire-lens-mcp MCP server. Vendored from kunology/STS2MCP under MIT.",
   "version": "0.3.4",
   "has_pck": false,
   "has_dll": true,


### PR DESCRIPTION
## Summary

- Rename the in-game mod manifest surface to `SpireLensMcpBridge`.
- Update bridge log prefixes, config filename, thread name, and HTTP greeting to say `SpireLensMcpBridge`.
- Update the external MCP server name/error text so connection failures distinguish the MCP server from the in-game bridge.

## Validation

- Not run here; this is a naming-only cleanup for the bridge/tooling surface.
- Consuming repo diagnostic run: https://github.com/nelsong6/spirelens/actions/runs/24922776201 now reports `SpireLensMcpBridge` readiness clearly.